### PR TITLE
Auto Retry on Rate Limit Reached

### DIFF
--- a/riot-api/build.gradle.kts
+++ b/riot-api/build.gradle.kts
@@ -9,7 +9,7 @@ version = "1.0-SNAPSHOT"
 
 dependencies {
     // Feign
-    implementation("io.github.openfeign:feign-core:13.3")
+    // implementation("io.github.openfeign:feign-core:13.3")
     implementation("io.github.openfeign:feign-moshi:13.3")
     implementation("com.squareup.moshi:moshi-kotlin:1.15.1")
 

--- a/riot-api/src/main/kotlin/com.noahkohrs.riot.api/ApiClientFactory.kt
+++ b/riot-api/src/main/kotlin/com.noahkohrs.riot.api/ApiClientFactory.kt
@@ -8,6 +8,7 @@ import com.noahkohrs.riot.api.values.Platform
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import feign.*
+import feign.codec.ErrorDecoder
 import feign.moshi.MoshiDecoder
 import feign.moshi.MoshiEncoder
 
@@ -25,21 +26,24 @@ internal class RiotApiRequestInterceptor(private val apiKey: String, private val
 
 internal class ApiClientFactory(private val baseUrl: String, private val apiKey: String, private val debug: Boolean = false) {
     // create a MoshiEncoder and MoshiDecoder
+    private val moshi =
+        Moshi.Builder()
+            .add(UnpredictableDtoAdapterFactory())
+            .add(KotlinJsonAdapterFactory())
+            .build()
+
     fun <T> createApiClient(apiType: Class<T>?): T {
-        val moshi =
-            Moshi.Builder()
-                .add(UnpredictableDtoAdapterFactory())
-                .add(KotlinJsonAdapterFactory())
-                .build()
         return Feign.builder()
             .decoder(MoshiDecoder(moshi))
             .encoder(MoshiEncoder(moshi))
+            .errorDecoder(RiotApiErrorDecoder())
+            .retryer(RiotApiRetryer())
             .requestInterceptor(RiotApiRequestInterceptor(apiKey, debug))
             .target(apiType, baseUrl)
     }
 }
 
-internal object RegionApiClientFactory {
+internal object PlatformApiClientFactory {
     fun create(
         apiKey: String,
         platform: Platform,
@@ -72,8 +76,12 @@ internal object GlobalRegionApiClientFactory {
     }
 }
 
+/**
+ * Planned to be replaced by an entire new module for the project.
+ *
+ * Do not expend.
+ */
 internal object StaticRiotDragoonFactory {
-    // create a MoshiEncoder and MoshiDecoder
     private const val STATIC_API_URL = "https://static.developer.riotgames.com"
 
     fun create(): StaticsRiotData.StaticDragoonApi {
@@ -82,5 +90,40 @@ internal object StaticRiotDragoonFactory {
             .decoder(MoshiDecoder(moshi))
             .encoder(MoshiEncoder(moshi))
             .target(StaticsRiotData.StaticDragoonApi::class.java, STATIC_API_URL)
+    }
+}
+
+internal class RiotApiErrorDecoder : ErrorDecoder {
+    private val defaultDecoder = ErrorDecoder.Default()
+
+    override fun decode(methodKey: String, response: Response): Exception {
+        return if (response.status() == 429) {
+            val retryAfter = response.headers()["Retry-After"]?.firstOrNull() ?: "1"
+            val waitTimeInSeconds = retryAfter.toLongOrNull() ?: 1
+
+            return RetryableException(
+                response.status(),
+                "Rate limit exceeded. Retrying after $waitTimeInSeconds seconds",
+                response.request().httpMethod(),
+                waitTimeInSeconds * 1000,
+                response.request(),
+            )
+        } else {
+            defaultDecoder.decode(methodKey, response)
+        }
+    }
+}
+
+internal class RiotApiRetryer : Retryer {
+    override fun continueOrPropagate(e: RetryableException) {
+        try {
+            Thread.sleep(e.retryAfter())
+        } catch (ignored: InterruptedException) {
+            Thread.currentThread().interrupt()
+        }
+    }
+
+    override fun clone(): Retryer {
+        return RiotApiRetryer()
     }
 }

--- a/riot-api/src/main/kotlin/com.noahkohrs.riot.api/lol/champion/ChampionApi.kt
+++ b/riot-api/src/main/kotlin/com.noahkohrs.riot.api/lol/champion/ChampionApi.kt
@@ -1,6 +1,6 @@
 package com.noahkohrs.riot.api.lol.champion
 
-import com.noahkohrs.riot.api.RegionApiClientFactory
+import com.noahkohrs.riot.api.PlatformApiClientFactory
 import com.noahkohrs.riot.api.dtos.ChampionInfo
 import com.noahkohrs.riot.api.values.Platform
 import feign.RequestLine
@@ -15,7 +15,7 @@ public class ChampionApi(
     platform: Platform,
 ) {
     private val apiClient =
-        RegionApiClientFactory
+        PlatformApiClientFactory
             .create(apiKey, platform)
             .createApiClient(ChampionApiClient::class.java)
 

--- a/riot-api/src/main/kotlin/com.noahkohrs.riot.api/lol/championmastery/ChampionMasteryApi.kt
+++ b/riot-api/src/main/kotlin/com.noahkohrs.riot.api/lol/championmastery/ChampionMasteryApi.kt
@@ -1,6 +1,6 @@
 package com.noahkohrs.riot.api.lol.championmastery
 
-import com.noahkohrs.riot.api.RegionApiClientFactory
+import com.noahkohrs.riot.api.PlatformApiClientFactory
 import com.noahkohrs.riot.api.dtos.ChampionMasteryDto
 import com.noahkohrs.riot.api.values.Platform
 import feign.Param
@@ -11,7 +11,7 @@ public class ChampionMasteryApi(
     platform: Platform,
 ) {
     private val apiClient =
-        RegionApiClientFactory
+        PlatformApiClientFactory
             .create(apiKey, platform)
             .createApiClient(ChampionMasteryApiClient::class.java)
 

--- a/riot-api/src/main/kotlin/com.noahkohrs.riot.api/lol/league/LeagueApi.kt
+++ b/riot-api/src/main/kotlin/com.noahkohrs.riot.api/lol/league/LeagueApi.kt
@@ -1,6 +1,6 @@
 package com.noahkohrs.riot.api.lol.league
 
-import com.noahkohrs.riot.api.RegionApiClientFactory
+import com.noahkohrs.riot.api.PlatformApiClientFactory
 import com.noahkohrs.riot.api.dtos.LeagueEntryDto
 import com.noahkohrs.riot.api.dtos.LeagueListDto
 import com.noahkohrs.riot.api.values.LoLDivision
@@ -15,7 +15,7 @@ public class LeagueApi(
     private val platform: Platform,
 ) {
     private val apiClient =
-        RegionApiClientFactory
+        PlatformApiClientFactory
             .create(apiKey, platform)
             .createApiClient(LeagueApiClient::class.java)
 

--- a/riot-api/src/main/kotlin/com.noahkohrs.riot.api/lol/leagueexp/LeagueExpApi.kt
+++ b/riot-api/src/main/kotlin/com.noahkohrs.riot.api/lol/leagueexp/LeagueExpApi.kt
@@ -1,6 +1,6 @@
 package com.noahkohrs.riot.api.lol.leagueexp
 
-import com.noahkohrs.riot.api.RegionApiClientFactory
+import com.noahkohrs.riot.api.PlatformApiClientFactory
 import com.noahkohrs.riot.api.dtos.LeagueEntryDto
 import com.noahkohrs.riot.api.values.LoLDivision
 import com.noahkohrs.riot.api.values.LoLRankedQueue
@@ -14,7 +14,7 @@ public class LeagueExpApi(
     private val platform: Platform,
 ) {
     private val apiClient =
-        RegionApiClientFactory
+        PlatformApiClientFactory
             .create(apiKey, platform)
             .createApiClient(LeagueExpApiClient::class.java)
 

--- a/riot-api/src/main/kotlin/com.noahkohrs.riot.api/lol/status/StatusApi.kt
+++ b/riot-api/src/main/kotlin/com.noahkohrs.riot.api/lol/status/StatusApi.kt
@@ -1,6 +1,6 @@
 package com.noahkohrs.riot.api.lol.status
 
-import com.noahkohrs.riot.api.RegionApiClientFactory
+import com.noahkohrs.riot.api.PlatformApiClientFactory
 import com.noahkohrs.riot.api.dtos.PlatformDataDto
 import com.noahkohrs.riot.api.values.Platform
 import feign.RequestLine
@@ -10,7 +10,7 @@ public class StatusApi(
     platform: Platform,
 ) {
     private val apiClient =
-        RegionApiClientFactory
+        PlatformApiClientFactory
             .create(apiKey, platform)
             .createApiClient(StatusApiClient::class.java)
 

--- a/riot-api/src/main/kotlin/com.noahkohrs.riot.api/lol/summoner/SummonerApi.kt
+++ b/riot-api/src/main/kotlin/com.noahkohrs.riot.api/lol/summoner/SummonerApi.kt
@@ -1,6 +1,6 @@
 package com.noahkohrs.riot.api.lol.summoner
 
-import com.noahkohrs.riot.api.RegionApiClientFactory
+import com.noahkohrs.riot.api.PlatformApiClientFactory
 import com.noahkohrs.riot.api.dtos.SummonerDto
 import com.noahkohrs.riot.api.values.Platform
 import feign.Param
@@ -11,7 +11,7 @@ public class SummonerApi(
     private val platform: Platform,
 ) {
     private val apiClient =
-        RegionApiClientFactory
+        PlatformApiClientFactory
             .create(apiKey, platform, debug = false)
             .createApiClient(SummonerApiClient::class.java)
 

--- a/riot-api/src/main/kotlin/com.noahkohrs.riot.api/templates/ExampleApi.kt
+++ b/riot-api/src/main/kotlin/com.noahkohrs.riot.api/templates/ExampleApi.kt
@@ -1,7 +1,7 @@
 package com.noahkohrs.riot.api.templates
 
 import apis.template.SomeResponse
-import com.noahkohrs.riot.api.RegionApiClientFactory
+import com.noahkohrs.riot.api.PlatformApiClientFactory
 import com.noahkohrs.riot.api.values.GlobalRegion
 import com.noahkohrs.riot.api.values.Platform
 import feign.RequestLine
@@ -14,7 +14,7 @@ public class ExampleApi(
     globalRegion: GlobalRegion,
 ) {
     private val apiClient =
-        RegionApiClientFactory
+        PlatformApiClientFactory
             .create(apiKey, platform)
             .createApiClient(ExampleApiClient::class.java)
 


### PR DESCRIPTION
The Riot Api now automatically retries the request whenever the rate limit is reached (#15).

This design is meant to work asynchronously, otherwise, it could cause incredibly long sleep and the main thread.